### PR TITLE
#1 investigation: emulator cleanup and jest cleanup

### DIFF
--- a/examples/postgres-server/package-lock.json
+++ b/examples/postgres-server/package-lock.json
@@ -13,10 +13,19 @@
       }
     },
     "../..": {
-      "version": "1.0.0",
+      "name": "pgmock",
+      "version": "1.0.3",
       "license": "MIT",
       "devDependencies": {
+        "@swc/core": "*",
+        "@swc/jest": "*",
+        "@types/jest": "*",
         "@types/node": "^20.12.2",
+        "@types/pg": "*",
+        "jest": "*",
+        "pg": "*",
+        "postgres": "^3.4.5",
+        "rimraf": "^5.0.5",
         "tsup": "^8.0.2",
         "typescript": "^5.4.3"
       }

--- a/examples/web-demo/package-lock.json
+++ b/examples/web-demo/package-lock.json
@@ -29,10 +29,18 @@
       }
     },
     "../..": {
-      "version": "1.0.2",
+      "name": "pgmock",
+      "version": "1.0.3",
       "license": "MIT",
       "devDependencies": {
+        "@swc/core": "*",
+        "@swc/jest": "*",
+        "@types/jest": "*",
         "@types/node": "^20.12.2",
+        "@types/pg": "*",
+        "jest": "*",
+        "pg": "*",
+        "postgres": "^3.4.5",
         "rimraf": "^5.0.5",
         "tsup": "^8.0.2",
         "typescript": "^5.4.3"

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+export default {
+    testTimeout: 30000,
+    verbose: true,
+    detectOpenHandles: true,
+    setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+    globalTeardown: '<rootDir>/jest.teardown.js',
+    transform: {
+      "^.+\\.(t|j)sx?$": "@swc/jest"
+    },
+  };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,34 @@
+beforeEach(() => {
+    console.log('\n[Test Starting]');
+  });
+  
+  afterEach(() => {
+    console.log('\n[Test Ending]');
+  });
+  
+  // Enhanced debug logging
+  afterAll(() => {
+    const handles = process._getActiveHandles();
+    console.log('\n[Active Handles Details]');
+    handles.forEach((handle, i) => {
+      console.log(`\nHandle ${i}:`);
+      if (handle instanceof require('net').Server) {
+        console.log('Type: Net Server');
+        console.log('Connections:', handle.connections);
+      } else if (handle instanceof require('net').Socket) {
+        console.log('Type: Net Socket');
+        console.log('Connected:', handle.connected);
+        console.log('Pending:', handle.pending);
+        console.log('Remote address:', handle.remoteAddress);
+        console.log('Local address:', handle.localAddress);
+      } else {
+        console.log('Type:', handle.constructor.name);
+      }
+    });
+  
+    const requests = process._getActiveRequests();
+    console.log('\n[Active Requests Details]');
+    requests.forEach((req, i) => {
+      console.log(`Request ${i}:`, req.constructor.name);
+    });
+  });

--- a/jest.teardown.js
+++ b/jest.teardown.js
@@ -1,0 +1,38 @@
+const teardown = async () => {
+    const logMemory = (label) => {
+        const heap = process.memoryUsage();
+        console.log(`\nMemory usage (${label}):`, {
+            heapUsed: Math.round(heap.heapUsed / 1024 / 1024) + 'MB',
+            heapTotal: Math.round(heap.heapTotal / 1024 / 1024) + 'MB',
+            external: Math.round(heap.external / 1024 / 1024) + 'MB',
+            arrayBuffers: Math.round(heap.arrayBuffers / 1024 / 1024) + 'MB'
+        });
+    };
+
+    console.log('\nStarting teardown...');
+    logMemory('initial');
+    
+    // Multiple GC passes
+    if (global.gc) {
+        for (let i = 0; i < 3; i++) {
+            global.gc();
+            await new Promise(resolve => setTimeout(resolve, 100));
+            logMemory(`gc pass ${i + 1}`);
+        }
+    }
+
+    // Try to clear WebAssembly memory
+    const handles = process._getActiveHandles();
+    handles.forEach(handle => {
+        if (handle.buffer) handle.buffer = null;
+        if ('destroy' in handle) handle.destroy();
+    });
+
+    // Final cleanup
+    if (global.gc) {
+        global.gc();
+        logMemory('final');
+    }
+};
+
+export default teardown;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pgmock",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pgmock",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "devDependencies": {
         "@swc/core": "*",
@@ -16,6 +16,7 @@
         "@types/pg": "*",
         "jest": "*",
         "pg": "*",
+        "postgres": "^3.4.5",
         "rimraf": "^5.0.5",
         "tsup": "^8.0.2",
         "typescript": "^5.4.3"
@@ -4787,6 +4788,20 @@
         "ts-node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/postgres": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.5.tgz",
+      "integrity": "sha512-cDWgoah1Gez9rN3H4165peY9qfpEo+SA61oQv65O3cRUE1pOEoJWwddwcqKE8XZYjbblOJlYDlLV4h67HrEVDg==",
+      "dev": true,
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
       }
     },
     "node_modules/postgres-array": {

--- a/package.json
+++ b/package.json
@@ -19,25 +19,28 @@
     "build": "rimraf dist/ && tsup src/main.ts --dts --splitting --format esm,cjs",
     "build-dev": "npm run build -- --sourcemap",
     "build-dev:watch": "npm run build-dev -- --watch",
-    "test": "jest --detectOpenHandles --forceExit"
+    "test": "NODE_DEBUG=gc node --expose-gc --max-old-space-size=512 --gc-interval=100 $(which jest) --detectOpenHandles --verbose --runInBand",
+    "test:debug": "NODE_DEBUG=gc,net node --inspect-brk --expose-gc $(which jest) --runInBand",
+    "test:memory": "NODE_DEBUG=gc node --expose-gc --trace-gc --max-old-space-size=512 $(which jest) --detectOpenHandles --runInBand",
+    "test:fast": "jest --runInBand --forceExit",
+    "test:ci": "jest --ci --runInBand --forceExit",
+    "test:watch": "jest --watch --runInBand",
+    "test:leak": "NODE_DEBUG=gc node --expose-gc --trace-gc --trace-gc-verbose scripts/memory-usage.js",
+    "test:heap": "NODE_DEBUG=gc node --expose-gc --heap-prof --heap-prof-interval=128 $(which jest) --runInBand"
   },
   "author": "Stan Wohlwend <n2d4xc@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^20.12.2",
-    "rimraf": "^5.0.5",
-    "tsup": "^8.0.2",
-    "typescript": "^5.4.3",
-    "jest": "*",
     "@swc/core": "*",
     "@swc/jest": "*",
     "@types/jest": "*",
+    "@types/node": "^20.12.2",
     "@types/pg": "*",
-    "pg": "*"
-  },
-  "jest": {
-    "transform": {
-      "^.+\\.(t|j)sx?$": "@swc/jest"
-    }
+    "jest": "*",
+    "pg": "*",
+    "postgres": "^3.4.5",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.2",
+    "typescript": "^5.4.3"
   }
 }

--- a/scripts/memory-usage.js
+++ b/scripts/memory-usage.js
@@ -1,0 +1,20 @@
+import { PostgresMock } from '../dist/main.cjs'
+
+async function runMemoryTest() {
+    console.log('Initial memory:', process.memoryUsage());
+    
+    const mock = await PostgresMock.create();
+    console.log('After create:', process.memoryUsage());
+    
+    await mock.destroy();
+    console.log('After destroy:', process.memoryUsage());
+    
+    if (global.gc) {
+        global.gc();
+        console.log('After GC:', process.memoryUsage());
+    }
+
+    process.exit(0)
+}
+
+runMemoryTest().catch(console.error);

--- a/src/jest.test.ts
+++ b/src/jest.test.ts
@@ -1,14 +1,195 @@
 
-import { PostgresMock } from '../dist/main.cjs'
-import * as pg from "pg";
+// import { PostgresMock } from '../dist/main.cjs'
+// import * as pg from "pg";
+// import postgres, { PostgresType, type Sql } from 'postgres'
 
-it('should work', async () => {
-    const mock = await PostgresMock.create();
-    const client = new pg.Client(mock.getNodePostgresConfig());
+// interface SqlWithMock extends Sql {
+//     mock?: PostgresMock;
+// }
 
-    await client.connect();
+// describe("Integration with", () => {
+//     // describe.skip("pg", () => {
+//     //     it('SELECT', async () => {
+//     //         const mock = await PostgresMock.create();
+//     //         const client = new pg.Client(mock.getNodePostgresConfig());
+        
+//     //         await client.connect();
+            
+//     //         expect(await client.query('SELECT $1::text as message', ['Hello world!'])).toMatchObject({ rows: [{ message: 'Hello world!' }] });
+        
+//     //         await client.end();
+//     //         mock.destroy();
+//     //     }, 30000)
+//     // })
+
+//     describe('postgres', () => {
+//         let sql: Sql;
+//         let mock: PostgresMock;
+
+//         beforeEach(async () => {
+//             mock = await PostgresMock.create();
+//         });
     
-    expect(await client.query('SELECT $1::text as message', ['Hello world!'])).toMatchObject({ rows: [{ message: 'Hello world!' }] });
+//         afterEach(async () => {
+//             try {
+//                 if (sql) {
+//                     await sql.end({ timeout: 5000 }).catch(() => {});
+//                 }
+//                 if (mock) {
+//                     await mock.destroy();
+//                 }
+//                 // Force close any remaining connections
+//                 await new Promise(resolve => setTimeout(resolve, 100));
+//             } catch (err) {
+//                 console.error('Cleanup error:', err);
+//             } 
+//             await new Promise(resolve => setTimeout(resolve, 500));
+//         });
+    
+//         it('INSERT', async () => {
+//             mock = await PostgresMock.create();
+//             const connectionString = await mock.listen(7777);
+//             sql = postgres(connectionString, {
+//                 // Add timeout settings to prevent hanging
+//                 idle_timeout: 2,
+//                 max_lifetime: 5,
+//                 max: 1,
+//                 connect_timeout: 10,
+//                 onclose: () => {},
+//             });
+    
+//             try {
+//                 // Create tables
+//                 await sql`
+//                     CREATE TABLE IF NOT EXISTS room (
+//                         id SERIAL PRIMARY KEY,
+//                         name TEXT NOT NULL
+//                     );
+//                 `;
+//                 await sql`
+//                     CREATE TABLE IF NOT EXISTS document (
+//                         id SERIAL PRIMARY KEY,
+//                         name TEXT NOT NULL,
+//                         room_id INTEGER NOT NULL REFERENCES room(id)
+//                     );
+//                 `;
+    
+//                 await sql`INSERT INTO room (id, name) VALUES (${'1'}, ${'Room One'});`;
+//                 await sql`INSERT INTO document (name, room_id) VALUES (${'DOCUMENT NAME TWO'}, ${'1'});`;  
+                
+//                 const documents = await sql`
+//                     SELECT id, name
+//                     FROM document
+//                     WHERE room_id = ${'1'}
+//                 `;
+                
+//                 expect(documents).toEqual(expect.arrayContaining([
+//                     expect.objectContaining({ name: "DOCUMENT NAME TWO" })
+//                 ]));
+//             } catch (error) {
+//                 console.error('Test error:', error);
+//                 throw error;
+//             } finally {
+//                 try {
+//                     await sql?.end({ timeout: 1000 }).catch(() => {});
+//                 } catch (err) {
+//                     console.error('Cleanup error in finally:', err);
+//                 }
+//             }
+//         }, 30000);
+//     });
+// })
 
-    await client.end();
-})
+
+import { PostgresMock } from '../dist/main.cjs'
+import postgres, { PostgresType, type Sql } from 'postgres'
+
+interface SqlWithMock extends Sql {
+    mock?: PostgresMock;
+}
+
+describe("Integration with", () => {
+    describe('postgres', () => {
+        let sql: Sql;
+        let mock: PostgresMock;
+        let cleanup: (() => void)[] = [];
+
+        beforeEach(async () => {
+            // Create mock only once
+            mock = await PostgresMock.create();
+            const connectionString = await mock.listen(7777);
+            sql = postgres(connectionString, {
+                idle_timeout: 2,
+                max_lifetime: 5,
+                max: 1,
+                connect_timeout: 10,
+                onclose: () => {},
+                // onend: () => {},
+            });
+        });
+    
+        afterEach(async () => {
+            try {
+                // Close SQL connection first
+                if (sql) {
+                    const sqlEndPromise = sql.end({ timeout: 1000 })
+                        .catch(e => console.error('SQL end error:', e));
+                    
+                    const timeoutPromise = new Promise<void>((_, reject) => {
+                        const id = setTimeout(() => {
+                            reject(new Error('SQL end timeout'));
+                        }, 1500);
+                        cleanup.push(() => clearTimeout(id));
+                    });
+    
+                    await Promise.race([sqlEndPromise, timeoutPromise]);
+                }
+    
+                // Then destroy mock
+                if (mock) {
+                    await mock.destroy();
+                }
+            } catch (err) {
+                console.error('Cleanup error:', err);
+            } finally {
+                // Clean up any remaining timeouts
+                cleanup.forEach(fn => fn());
+                cleanup = [];
+            }
+        });
+    
+        it('INSERT', async () => {
+            try {
+                await sql`
+                    CREATE TABLE IF NOT EXISTS room (
+                        id SERIAL PRIMARY KEY,
+                        name TEXT NOT NULL
+                    );
+                `;
+                await sql`
+                    CREATE TABLE IF NOT EXISTS document (
+                        id SERIAL PRIMARY KEY,
+                        name TEXT NOT NULL,
+                        room_id INTEGER NOT NULL REFERENCES room(id)
+                    );
+                `;
+    
+                await sql`INSERT INTO room (id, name) VALUES (${'1'}, ${'Room One'});`;
+                await sql`INSERT INTO document (name, room_id) VALUES (${'DOCUMENT NAME TWO'}, ${'1'});`;  
+                
+                const documents = await sql`
+                    SELECT id, name
+                    FROM document
+                    WHERE room_id = ${'1'}
+                `;
+                
+                expect(documents).toEqual(expect.arrayContaining([
+                    expect.objectContaining({ name: "DOCUMENT NAME TWO" })
+                ]));
+            } catch (error) {
+                console.error('Test error:', error);
+                throw error;
+            }
+        }, 30000);
+    });
+});

--- a/src/postgres-mock.ts
+++ b/src/postgres-mock.ts
@@ -1,9 +1,11 @@
+import { type Server } from "net";
 import { Ipv4Address } from "./addresses/ip-address.js";
 import { bootEmulator, sendScript } from "./boot.js";
 import { NodePostgresConnector } from "./connectors/node-postgres.js";
 import { PostgresConnectionSocket } from "./connectors/sockets.js";
 import { Logger } from "./logger.js";
 import { NetworkAdapter } from "./network-adapter.js";
+import net from "net"
 
 export type SerialConsole = {
   write(data: Uint8Array): void;
@@ -22,7 +24,12 @@ export type PostgresMockCreationOptions = {
 export class PostgresMock {
   private _curPort = 12400;
   private _curShellScriptId = 0;
-  private readonly _serialConsole: SerialConsole;
+  private _serialConsole: SerialConsole | null;
+  private server: Server | undefined;
+  private listeningServer: Server | undefined;
+  private abortServer: AbortController;
+  private activeSockets: Set<net.Socket> = new Set();  // Add this line
+
 
   private constructor(
     private _emulator: {
@@ -30,11 +37,17 @@ export class PostgresMock {
       add_listener: (event: string, callback: (e: any) => void) => void,
       serial0_send: (data: string) => void,
       destroy: () => void,
+      close: () => void,
+      stop: () => void,
+      wasm_memory: any,
     } | null
   ) {
     if (!_emulator) {
       throw new Error("Must use PostgresMock.create() to create a PostgresMock instance");
     }
+
+    this.abortServer = new AbortController()
+    this.setup()
 
     this._serialConsole = {
       write: (data: Uint8Array) => {
@@ -49,6 +62,34 @@ export class PostgresMock {
         _emulator.add_listener("serial0-output-byte", callback);
       },
     };
+  }
+
+  private async setup() {
+    this.server = net.createServer((socket) => {
+      this.activeSockets.add(socket);  // Track socket
+      const pgSocket = this.createSocket();
+      pgSocket.connect();
+      
+      socket.on("data", (data) => {
+        pgSocket.write(data);
+      });
+      pgSocket.on("data", (data) => {
+        socket.write(data);
+      });
+      socket.on("error", () => {
+        this.activeSockets.delete(socket);  // Remove tracked socket
+        socket.destroy();
+        pgSocket.destroy();
+      });
+      socket.on("close", () => {
+        this.activeSockets.delete(socket);  // Remove tracked socket
+        pgSocket.destroy();
+      });
+    });
+
+    this.server.on("error", (err) => {
+      console.error("Server error:", err);
+    });
   }
 
   /**
@@ -114,20 +155,13 @@ export class PostgresMock {
     }
     Logger.log("Dependencies imported");
     
-    const server = net.createServer((socket) => {
-      const pgSocket = this.createSocket();
-      pgSocket.connect();
-      socket.on("data", (data) => {
-        pgSocket.write(data);
-      });
-      pgSocket.on("data", (data) => {
-        socket.write(data);
-      });
-    });
     Logger.log("pgmock server created");
-  
-    await new Promise<void>(resolve => server.listen(port, resolve));
-    const actualPort = (server.address() as any).port;
+
+    this.listeningServer = this!.server!.listen({ 
+      port,
+      signal: this.abortServer.signal
+     })
+    const actualPort = (this.server!.address() as any).port;
     Logger.log("pgmock server listening on port", actualPort);
 
     return `postgresql://postgres:pgmock@localhost:${actualPort}`;
@@ -216,14 +250,54 @@ export class PostgresMock {
     Logger.log("Assigning new port", this._curPort);
     return this._curPort++;
   }
-
-  public destroy() {
+  public async destroy() {
     if (!this._emulator) {
       throw new Error("Postgres emulator has already been destroyed!");
     }
+    
+    console.log("\n=== PostgresMock Destroy Start ===");
 
-    Logger.log("Destroying PostgresMock.");
-    this._emulator.destroy();
-    this._emulator = null;
+    // Close servers first
+    await Promise.all([
+      this.server?.close(),
+      this.listeningServer?.close()
+    ]);
+
+    // Cleanup sockets
+    this.activeSockets.forEach(socket => socket.destroy());
+    this.activeSockets.clear();
+
+    // Aggressive emulator cleanup
+    if (this._emulator) {
+      // Stop the CPU
+      this._emulator.stop();
+      
+      // Clear the memory
+      if (this._emulator.wasm_memory) {
+        this._emulator.wasm_memory.free(); // Attempt to free WASM memory
+        this._emulator.wasm_memory = null;
+      }
+
+      // Destroy the emulator
+      this._emulator.destroy();
+      
+      // Clear all references
+      Object.keys(this._emulator).forEach(key => {
+        (this._emulator as any)[key] = null;
+      });
+      this._emulator = null;
+    }
+
+    // Clear all other references
+    this.server = undefined;
+    this.listeningServer = undefined;
+    this._serialConsole = null;
+
+    // Force a GC if available
+    if (global.gc) {
+      global.gc();
+    }
+    
+    console.log("=== PostgresMock Destroy Complete ===\n");
   }
 }


### PR DESCRIPTION
After further investigation in technical research with trying to force cleanup, implement better cleanup methods, and monitoring the resources being used throughout the test, it's been determined that even when the test has finished there is leftover memory that is not fully cleaned up instantly. We can observe this by running any one of our new test scripts:
```
"test:debug": "NODE_DEBUG=gc,net node --inspect-brk --expose-gc $(which jest) --runInBand",
  "test:memory": "NODE_DEBUG=gc node --expose-gc --trace-gc --max-old-space-size=512 $(which jest) --detectOpenHandles --runInBand",
  "test:fast": "jest --runInBand --forceExit",
  "test:leak": "NODE_DEBUG=gc node --expose-gc --trace-gc --trace-gc-verbose scripts/memory-usage.js",
  "test:heap": "NODE_DEBUG=gc node --expose-gc --heap-prof --heap-prof-interval=128 $(which jest) --runInBand"
```

All of which are intended to monitor the memory usage throughout the test. Upon observing the outputs, we can come to the conclusion that there is some issues with cleaning up the actual x86 emulator itself and has nothing to do with the implementation of tests or the `pgmock` library.

This is because the tests run and are all complete. With these changes, hanging occurs between in a duration 2-5 minutes after the test(s) have completed indicating a cleanup of the x86 emulator taking a long time.

In the future, if the x86 emulator does cleanup faster we can assume that pgmock can be safely used without needing jests `--forceExit` flag. 

Relates to #1